### PR TITLE
Disallow the use of `console` statements.

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ module.exports = {
     "linebreak-style":                    [ "error", "unix" ],
     "lines-between-class-members":        [ "warn", "always", { "exceptAfterSingleLine": true } ],
     "multiline-comment-style":            [ "warn", "separate-lines" ],
+    "no-console":                         [ "error" ],
     "no-duplicate-imports":               [ "error" ],
     "no-trailing-spaces":                 [ "warn", { "ignoreComments": true } ],
     "no-unused-vars":                     [ "error", { "argsIgnorePattern": "^_" } ], // Ignore "_variable".


### PR DESCRIPTION
I found a couple instances of `console.log` statements that I forgot to remove and got merged into our main branch. I think it is probably best to not allow `console` statements in our code-base. If we really need one, we can disable it for that particular line.